### PR TITLE
Update DataSink CRDS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,9 +395,7 @@ metadata:
   namespace: metrics-operator-system
 spec:
   connection:
-    endpoint: "https://your-tenant.live.dynatrace.com/api/v2/metrics/ingest"
-    protocol: "http"
-    insecureSkipVerify: false
+    endpoint: "https://your-tenant.live.dynatrace.com/api/v2/otlp/v1/metrics"
   authentication:
     apiKey:
       secretKeyRef:


### PR DESCRIPTION
When using DataSink and configure Dynatrace as backend system for storing metrics, OTLP endpoints of Dynatrace should be used.
Also, in the current version of the CRD, the connection field of the DataSink has only one field `endpoint`, while `protocol ` and `insecureSkipVerify` are not there.