### PR TITLE
fix(docs): `DataSink` CR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,8 +409,6 @@ The `DataSinkSpec` contains the following fields:
 
 #### Connection
 - **endpoint**: The target endpoint URL where metrics will be sent
-- **protocol**: Communication protocol (`http` or `grpc`)
-- **insecureSkipVerify**: (Optional) Skip TLS certificate verification
 
 #### Authentication
 - **apiKey**: API key authentication configuration


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request updates the `README.md` file to reflect changes in the configuration for connecting to the Dynatrace metrics API. The most notable changes include the removal of certain fields related to the connection protocol and security settings, as well as updating the endpoint URL.

Updates to Dynatrace connection configuration:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L398-R398): Changed the endpoint URL from `https://your-tenant.live.dynatrace.com/api/v2/metrics/ingest` to `https://your-tenant.live.dynatrace.com/api/v2/otlp/v1/metrics`. This reflects a shift to the OpenTelemetry Protocol (OTLP) for metrics ingestion.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L414-L415): Removed the `protocol` field and the `insecureSkipVerify` field. These fields are no longer relevant with the updated endpoint configuration.

**Which issue(s) this PR fixes**:
Fixes #32 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Fix `DataSink` CR example in README
```
