### PR TITLE
chore: update to go 1.24

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your release note in the below block.
+2. If no release note is required, just write "NONE" within the block.
+
+Format of block header: <category> <target_group>
+Possible values:
+- category:       breaking|feature|bugfix|doc|other
+- target_group:   user|operator|developer|dependency
+-->
+```feature user
+
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openmcp-project/metrics-operator
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades go.mod version to go 1.24.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Upgrade go version to 1.24
```