### PR TITLE
feat(datasinkref): openapi schema spec defaulting

### DIFF
--- a/api/v1alpha1/federatedmanagedmetric_types.go
+++ b/api/v1alpha1/federatedmanagedmetric_types.go
@@ -45,6 +45,7 @@ type FederatedManagedMetricSpec struct {
 	// If not specified, the DataSink named "default" in the operator's
 	// namespace will be used.
 	// +optional
+	// +kubebuilder:default:={}
 	DataSinkRef *DataSinkReference `json:"dataSinkRef,omitempty"`
 
 	FederatedClusterAccessRef FederateClusterAccessRef `json:"federateClusterAccessRef,omitempty"`

--- a/api/v1alpha1/federatedmetric_types.go
+++ b/api/v1alpha1/federatedmetric_types.go
@@ -48,6 +48,7 @@ type FederatedMetricSpec struct {
 	// If not specified, the DataSink named "default" in the operator's
 	// namespace will be used.
 	// +optional
+	// +kubebuilder:default:={}
 	DataSinkRef *DataSinkReference `json:"dataSinkRef,omitempty"`
 
 	FederatedClusterAccessRef FederateClusterAccessRef `json:"federateClusterAccessRef,omitempty"`

--- a/api/v1alpha1/managedmetric_types.go
+++ b/api/v1alpha1/managedmetric_types.go
@@ -50,6 +50,7 @@ type ManagedMetricSpec struct {
 	// If not specified, the DataSink named "default" in the operator's
 	// namespace will be used.
 	// +optional
+	// +kubebuilder:default:={}
 	DataSinkRef *DataSinkReference `json:"dataSinkRef,omitempty"`
 
 	// +optional

--- a/api/v1alpha1/metric_types.go
+++ b/api/v1alpha1/metric_types.go
@@ -39,8 +39,9 @@ const (
 // DataSinkReference holds a reference to a DataSink resource.
 type DataSinkReference struct {
 	// Name is the name of the DataSink resource.
-	// +kubebuilder:validation:Required
-	Name string `json:"name"`
+	// +optional
+	// +kubebuilder:default:="default"
+	Name string `json:"name,omitempty"`
 }
 
 // MetricSpec defines the desired state of Metric
@@ -66,6 +67,7 @@ type MetricSpec struct {
 	// If not specified, the DataSink named "default" in the operator's
 	// namespace will be used.
 	// +optional
+	// +kubebuilder:default:={}
 	DataSinkRef *DataSinkReference `json:"dataSinkRef,omitempty"`
 
 	// +optional

--- a/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_federatedmanagedmetrics.yaml
+++ b/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_federatedmanagedmetrics.yaml
@@ -41,16 +41,16 @@ spec:
             description: FederatedManagedMetricSpec defines the desired state of FederatedManagedMetric
             properties:
               dataSinkRef:
+                default: {}
                 description: |-
                   DataSinkRef specifies the DataSink to be used for this federated managed metric.
                   If not specified, the DataSink named "default" in the operator's
                   namespace will be used.
                 properties:
                   name:
+                    default: default
                     description: Name is the name of the DataSink resource.
                     type: string
-                required:
-                - name
                 type: object
               description:
                 type: string

--- a/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_federatedmetrics.yaml
+++ b/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_federatedmetrics.yaml
@@ -40,16 +40,16 @@ spec:
             description: FederatedMetricSpec defines the desired state of FederatedMetric
             properties:
               dataSinkRef:
+                default: {}
                 description: |-
                   DataSinkRef specifies the DataSink to be used for this federated metric.
                   If not specified, the DataSink named "default" in the operator's
                   namespace will be used.
                 properties:
                   name:
+                    default: default
                     description: Name is the name of the DataSink resource.
                     type: string
-                required:
-                - name
                 type: object
               description:
                 type: string

--- a/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_managedmetrics.yaml
+++ b/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_managedmetrics.yaml
@@ -50,16 +50,16 @@ spec:
             description: ManagedMetricSpec defines the desired state of ManagedMetric
             properties:
               dataSinkRef:
+                default: {}
                 description: |-
                   DataSinkRef specifies the DataSink to be used for this managed metric.
                   If not specified, the DataSink named "default" in the operator's
                   namespace will be used.
                 properties:
                   name:
+                    default: default
                     description: Name is the name of the DataSink resource.
                     type: string
-                required:
-                - name
                 type: object
               description:
                 description: Sets the description that will be used to identify the

--- a/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_metrics.yaml
+++ b/cmd/metrics-operator/embedded/crds/metrics.openmcp.cloud_metrics.yaml
@@ -50,16 +50,16 @@ spec:
             description: MetricSpec defines the desired state of Metric
             properties:
               dataSinkRef:
+                default: {}
                 description: |-
                   DataSinkRef specifies the DataSink to be used for this metric.
                   If not specified, the DataSink named "default" in the operator's
                   namespace will be used.
                 properties:
                   name:
+                    default: default
                     description: Name is the name of the DataSink resource.
                     type: string
-                required:
-                - name
                 type: object
               description:
                 description: Sets the description that will be used to identify the

--- a/internal/controller/metric_controller_test.go
+++ b/internal/controller/metric_controller_test.go
@@ -165,6 +165,36 @@ func TestMetricController(t *testing.T) {
 	t.Run("TestReconcileMetricHappyPath", testReconcileMetricHappyPath)
 	t.Run("TestReconcileMetricNotFound", testReconcileMetricNotFound)
 	t.Run("TestReconcileDataSinkNotFound", testReconcileSecretNotFound)
+	t.Run("TestDataSinkRefDefault", testDataSinkRefDefault)
+}
+
+func testDataSinkRefDefault(t *testing.T) {
+	metric := types.NamespacedName{
+		Name:      "data-sink-default",
+		Namespace: "default",
+	}
+	ctx := context.Background()
+
+	// create metric
+	in := &v1alpha1.Metric{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      metric.Name,
+			Namespace: metric.Namespace,
+		},
+		Spec: v1alpha1.MetricSpec{
+			Name: "test",
+		},
+	}
+	err := k8sClient.Create(ctx, in)
+	require.NoError(t, err, "failed to create metric")
+
+	// fetch metric
+	var out v1alpha1.Metric
+	err = k8sClient.Get(ctx, metric, &out)
+	require.NoError(t, err, "failed to fetch metric")
+
+	// verify result
+	require.Equal(t, &v1alpha1.DataSinkReference{Name: "default"}, out.Spec.DataSinkRef)
 }
 
 // testReconcileMetricNotFound tests the behavior when the Metric is not found


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces basic api server defaulting for the data sink reference of all metric types.

Fixes #30 

**Special notes for your reviewer**:

The empty object in the parent struct triggers the defaulting when no dataSinkRef is provided.
Note that this doesn't cover the case of a user explicitly specifying a data sink with an empty string ("") which is handled in the controller but there is no proper way to handle this in openapi. minLength=1 would be a potential workaround but this felt like such an edge case that i left it out and i definitely would not introduce a mutating webhook for this.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <feature> <u>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
reflect data sink defaulting in the spec of metric CRs
```