### PR TITLE
Add registry portion to values file

### DIFF
--- a/charts/metrics-operator/templates/deployment.yaml
+++ b/charts/metrics-operator/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}-init
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ ternary "" (print (.Values.global).imageRegistry "/") (empty (.Values.global).imageRegistry) }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - init
@@ -108,7 +108,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ ternary "" (print (.Values.global).imageRegistry "/") (empty (.Values.global).imageRegistry) }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - start


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR introduces a new variable global.imageRegistry which allows users to separately define the registry where the image is hosted. This is handy when it comes down to building localization rules in OCM. By having the repository containing the registry + repository strings, [OCM localization rules](https://github.com/open-component-model/ocm-controller/blob/255953ae7d7afea64a2bae9ec67c3fe686f04256/controllers/mutation_reconcile_looper.go#L453-L480) cannot simply substitute the corresponding values and users will be required to add additional logic just to separate the two. 

The change will basically allow users to either define the image path as:

```
# values.yaml
global:
  imageRegistry: ghcr.io

image:
  repository: openmcp-project/github.com/openmcp-project/metrics-operator/images/metrics-operator
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: v0.6.1
#
# Deployment spec result:
image: "ghcr.io/openmcp-project/github.com/openmcp-project/metrics-operator/images/metrics-operator:v0.6.1"
```

or 
```
# values.yaml
image:
  repository: ghcr.io/openmcp-project/github.com/openmcp-project/metrics-operator/images/metrics-operator
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: v0.6.1
#
# Deployment spec result:
image: "ghcr.io/openmcp-project/github.com/openmcp-project/metrics-operator/images/metrics-operator:v0.6.1"
```

**Release note**:
Add new registry value

