### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,16 +27,5 @@
       ],
       "rangeStrategy": "bump"
     },
-    {
-      "description": "Combine crossplane updates in a single PR",
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackageNames": [
-        "^github\\.com/crossplane"
-      ],
-      "groupName": "crossplane dependencies",
-      "groupSlug": "crossplane-dependencies"
-    },
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the renovate config to adhere to our setup in other repositories. Most importantly, it will turn on the look up for git submodule dependencies to get automatically updated by renovate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```