### PR TITLE
Metric multi dimensions

### DIFF
--- a/internal/orchestrator/metrichandler.go
+++ b/internal/orchestrator/metrichandler.go
@@ -160,7 +160,7 @@ func (e *projectedField) GetID() string {
 }
 
 func (h *MetricHandler) extractProjectionGroupsFrom(list *unstructured.UnstructuredList) map[string][][]projectedField {
-	var collection [][]projectedField
+	collection := make([][]projectedField, 0, len(list.Items))
 
 	for _, obj := range list.Items {
 		var fields []projectedField


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR adds support for multi projections/dimension on regular k8s metrics.

**Which issue(s) this PR fixes**:
Fixes #104 

**Special notes for your reviewer**:
No additional tests have been added to the project. The purpose of the current PR is to evaluate the logic first.

**Release note**:
```feature operator
Adding support for multi dimensions on built-in metrics, e.g.

apiVersion: metrics.openmcp.cloud/v1alpha1
kind: Metric
metadata:
  name: mcp-deploy
spec:
  dataSinkRef:
    name: local
  description: Deployments
  interval: 1m
  name: mcp-deploy
  target:
    group: apps
    kind: Deployment
    version: v1
  projections:
  - fieldPath: metadata.namespace
    name: namespace
  - fieldPath: "status.conditions[?(@.type=='Available')].status"
    name: available
```