### PR TITLE
chore: replace hardcoded secret paths with generic gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,10 +27,9 @@ Dockerfile.cross
 *.swo
 *~
 
-# exclude secret
-examples/sample_secret.yaml
-examples/secret.yaml
-examples/datasink/dynatrace-prod-setup.yaml
+# exclude secrets
+secret.yaml
+*.secret.yaml
 
 # debug file
 *debug*

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -24,7 +24,7 @@ tasks:
     internal: true
     cmds:
     - test -s {{.ROOT_DIR}}/bin/kustomize || GOBIN={{.ROOT_DIR}}/bin/ GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@{{.KUSTOMIZE_VERSION}}
-  
+
   dev:crd:install:
     desc: "Install CRDs into the K8s cluster specified in ~/.kube/config"
     deps:
@@ -95,8 +95,8 @@ tasks:
     - task dev:operator-namespace
     - task dev:basic-metric
     - task dev:managed-metric
-    - test -e {{.ROOT_DIR}}/examples/datasink/dynatrace-prod-setup.yaml && task dev:dynatrace-prod-setup || echo -e '\n\nYou should add your dynatrace configuration here {{.ROOT_DIR}}/examples/datasink/dynatrace-prod-setup.yaml\n\n'
-     
+    - test -e {{.ROOT_DIR}}/examples/datasink/dynatrace-prod-secret.yaml && task dev:dynatrace-prod-setup || echo -e '\n\nYou should add your dynatrace configuration here {{.ROOT_DIR}}/examples/datasink/dynatrace-prod-secret.yaml\n\n'
+
 
   dev:operator-namespace:
     desc: "Create the operator namespace if it does not exist."
@@ -116,7 +116,7 @@ tasks:
   dev:dynatrace-prod-setup:
     desc: "Apply Dynatrace production setup example to the cluster."
     cmds:
-      - kubectl apply -f {{.ROOT_DIR}}/examples/datasink/dynatrace-prod-setup.yaml
+      - kubectl apply -f {{.ROOT_DIR}}/examples/datasink/dynatrace-prod-secret.yaml
 
   dev:metric-dynatrace-prod:
     desc: "Apply metric using Dynatrace production example to the cluster."
@@ -129,7 +129,7 @@ tasks:
       - task dev:crossplane:install
       - task dev:crossplane:provider:install
       - task dev:helm-provider-sample
-  
+
   dev:crossplane:install:
     desc: "Install Crossplane into the cluster via Helm"
     deps:

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,11 +19,11 @@ git submodule update --init
 2. Configure a DataSink for local testing. Copy the example and fill in your credentials:
 
 ```bash
-cp examples/datasink/basic-datasink.yaml examples/datasink/dynatrace-prod-setup.yaml
-# edit dynatrace-prod-setup.yaml with your endpoint and credentials
+cp examples/datasink/basic-datasink.yaml examples/datasink/dynatrace-prod-secret.yaml
+# edit dynatrace-prod-secret.yaml with your endpoint and credentials
 ```
 
-> The `examples/datasink/dynatrace-prod-setup.yaml` path is in `.gitignore` — safe to put real credentials here locally.
+> The `*.secret.yaml` path is in `.gitignore` — safe to put real credentials here locally.
 
 3. Set up a local kind cluster with all CRDs, Crossplane, and sample resources:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace hardcoded secret file paths in `.gitignore` with generic patterns (`secret.yaml`, `*.secret.yaml`) so any file following the naming convention is automatically excluded. Renames the Dynatrace example file accordingly.

Motivated by: https://github.com/openmcp-project/metrics-operator/pull/242#discussion_r3682455894

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Use `*.secret.yaml` naming convention for local secret files — these are now gitignored by pattern instead of explicit path.
```