### PR TITLE
fix: resolve goconst lint errors from stricter golangci-lint v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,10 +21,18 @@ linters:
     - unparam
     - unused
   settings:
+    goconst:
+      min-len: 3
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings
   exclusions:
+    rules:
+      - path: "_test\\.go"
+        linters:
+          - goconst
+          - dupl
     generated: lax
     presets:
       - comments

--- a/internal/orchestrator/federatedmanagedhandler.go
+++ b/internal/orchestrator/federatedmanagedhandler.go
@@ -102,7 +102,7 @@ func (h *FederatedManagedHandler) Monitor(ctx context.Context) (MonitorResult, e
 	}
 
 	result.Phase = v1alpha1.PhaseActive
-	result.Reason = "MonitoringActive"
+	result.Reason = v1alpha1.ReasonMonitoringActive
 	result.Message = fmt.Sprintf("metric is monitoring federated managed resources '%s'", h.metric.Name)
 
 	if dimensions != nil {

--- a/internal/orchestrator/managedhandler.go
+++ b/internal/orchestrator/managedhandler.go
@@ -133,7 +133,7 @@ func (h *ManagedHandler) Monitor(ctx context.Context) (MonitorResult, error) {
 	} else {
 		result.Phase = v1alpha1.PhaseActive
 		result.Observation = &v1alpha1.ManagedObservation{Timestamp: metav1.Now(), Resources: resources}
-		result.Reason = "MonitoringActive"
+		result.Reason = v1alpha1.ReasonMonitoringActive
 		result.Message = fmt.Sprintf("metric is monitoring resource '%s'", h.metric.GvkToString())
 	}
 

--- a/internal/orchestrator/metrichandler.go
+++ b/internal/orchestrator/metrichandler.go
@@ -74,7 +74,7 @@ func (h *MetricHandler) simpleMonitor(ctx context.Context, list *unstructured.Un
 	return MonitorResult{
 		Observation: metricObservation,
 		Phase:       v1alpha1.PhaseActive,
-		Reason:      "MonitoringActive",
+		Reason:      v1alpha1.ReasonMonitoringActive,
 		Message:     fmt.Sprintf("metric value recorded for resource '%s'", h.metric.GvkToString()),
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes goconst lint errors introduced by the updated golangci-lint v2.11.3+ in the `hack/common` build submodule (renovate PR #240). The new version enforces `goconst` with default `min-occurrences: 3`, but `.golangci.yaml` had no goconst settings — the old settings lived in `.golangci.yml` which `run-lint.sh` never reads.

**Which issue(s) this PR fixes**:
Fixes #240 (unblocks the renovate build bump)

**Special notes for your reviewer**:
- `.golangci.yml` (old, ignored) had `min-occurrences: 5`; `.golangci.yaml` (used by CI) had none — this PR aligns them
- Test files are excluded from `goconst` and `dupl` to match the old config behaviour
- `"MonitoringActive"` raw literals in production code replaced with the already-existing `v1alpha1.ReasonMonitoringActive` constant

**Release note**:
```other developer
Fix goconst lint errors caused by stricter golangci-lint v2 defaults
```