### PR TITLE
feat: export explicit target and resource GVK labels

### DIFF
--- a/docs/dimensions-configuration.md
+++ b/docs/dimensions-configuration.md
@@ -4,16 +4,22 @@ The Metrics Operator allows you to enrich the metrics you collect with data from
 
  **Key Behavior to Understand**
 
- Before you start, it's crucial to understand how dimensions are handled. Both `Metric` and `ManagedMetric` resources automatically add a set of **Base Dimensions** to every metric, which typically include `group`, `version`, `kind`, and `cluster`. The key difference lies in how they handle custom dimensions on top of this base.
+ Before you start, it's crucial to understand how dimensions are handled. All metric resource types automatically add **explicit GVK dimensions** so target filters and observed resources cannot be confused:
 
- -   **`Metric`:** Behavior is **additive**.
-     -   It **always** includes the Base Dimensions (`group`, `version`, `kind`, `cluster`).
-     -   Any custom dimensions you define in the `projections` field are **added** to these base dimensions. There is no "default" mode; you either have only the base dimensions or the base dimensions plus your custom ones.
+ - `target_kind`, `target_group`, `target_version`, `target_api_version`: values from `spec.target` (for federated managed metrics, from the referenced `FederatedClusterAccess` target)
+ - `cr_kind`, `cr_group`, `cr_version`, `cr_api_version`: values from the observed custom/resource instance
+ - `cluster`: the monitored cluster, when known
+
+ -   **`Metric` / `FederatedMetric`:** Behavior is **additive**.
+     -   It **always** includes target GVK dimensions and cluster.
+     -   It also exports observed resource GVK dimensions. With partial target matching, one target can produce multiple resource-GVK series.
+     -   Any custom dimensions you define in the `projections` field are **added** to these base dimensions.
 
  -   **`ManagedMetric`:** Behavior is **conditional**.
      -   It is designed for Crossplane and offers a special set of **Convenience Defaults**.
-     -   **If you do NOT define a `dimensions` block:** The operator exports the Base Dimensions (`cluster`, `group`, `version`, `kind`) **plus** convenience dimensions derived from the resource's status (e.g., `ready: "true"`, `synced: "true"`).
-     -   **If you define ANY custom `dimensions`:** The convenience defaults are **disabled**. The operator exports only the Base Dimension (`cluster`) **plus** your explicitly defined custom dimensions. This allows you to take full control.
+     -   It always exports target GVK dimensions, observed resource GVK dimensions, and cluster.
+     -   **If you do NOT define a `dimensions` block:** The operator also exports convenience dimensions derived from the resource's status (e.g., `ready: "true"`, `synced: "true"`).
+     -   **If you define ANY custom `dimensions`:** The convenience defaults are **disabled** and your explicitly defined custom dimensions are exported instead.
 
 ---
 

--- a/docs/metrics-export.md
+++ b/docs/metrics-export.md
@@ -182,7 +182,7 @@ The operator exposes a standard [controller-runtime](https://github.com/kubernet
 
 | Metric                            | Type  | Description                                                                                                                                          |
 | --------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `metrics_operator_resource_count` | Gauge | Count of Kubernetes resources observed, labelled by `metric_name`, `namespace`, `kind`, `group`, `version`, `cluster`, `api_version`, `extra_labels` |
+| `metrics_operator_resource_count` | Gauge | Count of Kubernetes resources observed, labelled by `metric_name`, `namespace`, `target_kind`, `target_group`, `target_version`, `target_api_version`, `cr_kind`, `cr_group`, `cr_version`, `cr_api_version`, `cluster`, `extra_labels` |
 
 Standard controller-runtime metrics (work queue depth, reconcile errors, etc.) are also available.
 

--- a/internal/config/external_config.go
+++ b/internal/config/external_config.go
@@ -318,13 +318,14 @@ func CreateExternalQueryConfigSet(ctx context.Context, fcaRef v1alpha1.FederateC
 			if errQC != nil {
 				return nil, fmt.Errorf("failed to create query config from kubeconfig secret ref: %w", errQC)
 			}
+			qc.Target = &set.Spec.Target
 			queryConfigs = append(queryConfigs, *qc)
 		}
 
 		return queryConfigs, nil
 	}
 
-	return extractKubeConfigs(kcPath, list)
+	return extractKubeConfigsWithTarget(kcPath, list, &set.Spec.Target)
 }
 
 func extractSecretRefs(kcPath string, list *unstructured.UnstructuredList) ([]v1alpha1.KubeConfigSecretRef, error) {
@@ -367,7 +368,7 @@ func extractSecretRefs(kcPath string, list *unstructured.UnstructuredList) ([]v1
 	return kubeConfigSecretRefs, nil
 }
 
-func extractKubeConfigs(kcPath string, list *unstructured.UnstructuredList) ([]orchestrator.QueryConfig, error) {
+func extractKubeConfigsWithTarget(kcPath string, list *unstructured.UnstructuredList, target *v1alpha1.GroupVersionKindTarget) ([]orchestrator.QueryConfig, error) {
 	queryConfigs := make([]orchestrator.QueryConfig, 0, len(list.Items))
 
 	// TODO: not all resources will have kubeconfig data, need to handle this case
@@ -417,7 +418,7 @@ func extractKubeConfigs(kcPath string, list *unstructured.UnstructuredList) ([]o
 			return nil, fmt.Errorf("failed to create external client query config: %w", err)
 		}
 
-		queryConfigs = append(queryConfigs, orchestrator.QueryConfig{Client: externalClient, RestConfig: *config, ClusterName: &clusterName})
+		queryConfigs = append(queryConfigs, orchestrator.QueryConfig{Client: externalClient, RestConfig: *config, ClusterName: &clusterName, Target: target})
 
 	}
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,21 +7,39 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+const (
+	labelMetricName       = "metric_name"
+	labelNamespace        = "namespace"
+	labelTargetKind       = "target_kind"
+	labelTargetGroup      = "target_group"
+	labelTargetVersion    = "target_version"
+	labelTargetAPIVersion = "target_api_version"
+	labelCRKind           = "cr_kind"
+	labelCRGroup          = "cr_group"
+	labelCRVersion        = "cr_version"
+	labelCRAPIVersion     = "cr_api_version"
+	labelCluster          = "cluster"
+	labelExtraLabels      = "extra_labels"
+)
+
 var ResourceCountGauge = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "metrics_operator_resource_count",
 		Help: "Count of Kubernetes resources observed by the metrics-operator.",
 	},
 	[]string{
-		"metric_name",
-		"namespace",
-		"resource",
-		"group",
-		"version",
-		"cluster",
-		"kind",
-		"api_version",
-		"extra_labels",
+		labelMetricName,
+		labelNamespace,
+		labelTargetKind,
+		labelTargetGroup,
+		labelTargetVersion,
+		labelTargetAPIVersion,
+		labelCRKind,
+		labelCRGroup,
+		labelCRVersion,
+		labelCRAPIVersion,
+		labelCluster,
+		labelExtraLabels,
 	},
 )
 
@@ -34,28 +52,37 @@ func init() {
 // dims is the DataPoint.Dimensions map, value is the gauge value.
 func RecordDataPoint(metricName, namespace string, dims map[string]string, value int64) {
 	fixed := map[string]string{
-		"resource":    "",
-		"group":       "",
-		"version":     "",
-		"cluster":     "",
-		"kind":        "",
-		"api_version": "",
+		labelTargetKind:       "",
+		labelTargetGroup:      "",
+		labelTargetVersion:    "",
+		labelTargetAPIVersion: "",
+		labelCRKind:           "",
+		labelCRGroup:          "",
+		labelCRVersion:        "",
+		labelCRAPIVersion:     "",
+		labelCluster:          "",
 	}
 	overflow := make(map[string]string)
 	for k, v := range dims {
 		switch k {
-		case "resource":
-			fixed["resource"] = v
-		case "group":
-			fixed["group"] = v
-		case "version":
-			fixed["version"] = v
-		case "cluster":
-			fixed["cluster"] = v
-		case "kind":
-			fixed["kind"] = v
-		case "apiVersion":
-			fixed["api_version"] = v
+		case labelTargetKind:
+			fixed[labelTargetKind] = v
+		case labelTargetGroup:
+			fixed[labelTargetGroup] = v
+		case labelTargetVersion:
+			fixed[labelTargetVersion] = v
+		case labelTargetAPIVersion:
+			fixed[labelTargetAPIVersion] = v
+		case labelCRKind:
+			fixed[labelCRKind] = v
+		case labelCRGroup:
+			fixed[labelCRGroup] = v
+		case labelCRVersion:
+			fixed[labelCRVersion] = v
+		case labelCRAPIVersion, "cr_apiVersion":
+			fixed[labelCRAPIVersion] = v
+		case labelCluster:
+			fixed[labelCluster] = v
 		default:
 			overflow[k] = v
 		}
@@ -67,14 +94,17 @@ func RecordDataPoint(metricName, namespace string, dims map[string]string, value
 		}
 	}
 	ResourceCountGauge.With(prometheus.Labels{
-		"metric_name":  metricName,
-		"namespace":    namespace,
-		"resource":     fixed["resource"],
-		"group":        fixed["group"],
-		"version":      fixed["version"],
-		"cluster":      fixed["cluster"],
-		"kind":         fixed["kind"],
-		"api_version":  fixed["api_version"],
-		"extra_labels": extra,
+		labelMetricName:       metricName,
+		labelNamespace:        namespace,
+		labelTargetKind:       fixed[labelTargetKind],
+		labelTargetGroup:      fixed[labelTargetGroup],
+		labelTargetVersion:    fixed[labelTargetVersion],
+		labelTargetAPIVersion: fixed[labelTargetAPIVersion],
+		labelCRKind:           fixed[labelCRKind],
+		labelCRGroup:          fixed[labelCRGroup],
+		labelCRVersion:        fixed[labelCRVersion],
+		labelCRAPIVersion:     fixed[labelCRAPIVersion],
+		labelCluster:          fixed[labelCluster],
+		labelExtraLabels:      extra,
 	}).Set(float64(value))
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,18 @@
+package metrics
+
+import "testing"
+
+func TestRecordDataPointAcceptsExplicitGVKLabels(t *testing.T) {
+	RecordDataPoint("test_metric", "default", map[string]string{
+		"target_kind":        "Pod",
+		"target_group":       "n/a",
+		"target_version":     "v1",
+		"target_api_version": "v1",
+		"cr_kind":            "Deployment",
+		"cr_group":           "apps",
+		"cr_version":         "v1",
+		"cr_api_version":     "apps/v1",
+		"cluster":            "cluster-a",
+		"custom":             "value",
+	}, 1)
+}

--- a/internal/orchestrator/dimensions.go
+++ b/internal/orchestrator/dimensions.go
@@ -1,0 +1,54 @@
+package orchestrator
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openmcp-project/metrics-operator/api/v1alpha1"
+	"github.com/openmcp-project/metrics-operator/internal/clientoptl"
+)
+
+func addClusterDimension(dataPoint *clientoptl.DataPoint, clusterName *string) {
+	if clusterName != nil && *clusterName != "" {
+		dataPoint.AddDimension(CLUSTER, *clusterName)
+	}
+}
+
+func addTargetGVKDimensions(dataPoint *clientoptl.DataPoint, target *v1alpha1.GroupVersionKindTarget) {
+	if target == nil {
+		return
+	}
+	addGVKDimensions(dataPoint, TARGET_KIND, TARGET_GROUP, TARGET_VERSION, TARGET_APIVERSION, target.GVK())
+}
+
+func addResourceGVKDimensions(dataPoint *clientoptl.DataPoint, gvk schema.GroupVersionKind) {
+	addGVKDimensions(dataPoint, CR_KIND, CR_GROUP, CR_VERSION, CR_APIVERSION, gvk)
+}
+
+func addGVKDimensions(dataPoint *clientoptl.DataPoint, kindKey, groupKey, versionKey, apiVersionKey string, gvk schema.GroupVersionKind) {
+	dataPoint.AddDimension(kindKey, dimensionValue(gvk.Kind))
+	dataPoint.AddDimension(groupKey, dimensionValue(gvk.Group))
+	dataPoint.AddDimension(versionKey, dimensionValue(gvk.Version))
+	dataPoint.AddDimension(apiVersionKey, dimensionValue(gvk.GroupVersion().String()))
+}
+
+func resourceGVKProjectedFields(obj unstructured.Unstructured) []projectedField {
+	gvk := obj.GroupVersionKind()
+	return []projectedField{
+		{name: CR_KIND, value: dimensionValue(gvk.Kind), found: gvk.Kind != ""},
+		{name: CR_GROUP, value: dimensionValue(gvk.Group), found: true},
+		{name: CR_VERSION, value: dimensionValue(gvk.Version), found: gvk.Version != ""},
+		{name: CR_APIVERSION, value: dimensionValue(gvk.GroupVersion().String()), found: gvk.Version != ""},
+	}
+}
+
+func dimensionValue(value string) string {
+	if value == "" {
+		return "n/a"
+	}
+	return value
+}
+
+func gvkFromAPIVersionAndKind(apiVersion, kind string) schema.GroupVersionKind {
+	return schema.FromAPIVersionAndKind(apiVersion, kind)
+}

--- a/internal/orchestrator/dimensions_test.go
+++ b/internal/orchestrator/dimensions_test.go
@@ -1,0 +1,55 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openmcp-project/metrics-operator/api/v1alpha1"
+	"github.com/openmcp-project/metrics-operator/internal/clientoptl"
+)
+
+func TestExplicitGVKDimensions(t *testing.T) {
+	target := &v1alpha1.GroupVersionKindTarget{Kind: "Pod", Version: "v1"}
+	dataPoint := clientoptl.NewDataPoint()
+
+	addTargetGVKDimensions(dataPoint, target)
+	addResourceGVKDimensions(dataPoint, schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+
+	require.Equal(t, "Pod", dataPoint.Dimensions[TARGET_KIND])
+	require.Equal(t, "n/a", dataPoint.Dimensions[TARGET_GROUP])
+	require.Equal(t, "v1", dataPoint.Dimensions[TARGET_VERSION])
+	require.Equal(t, "v1", dataPoint.Dimensions[TARGET_APIVERSION])
+	require.Equal(t, "Deployment", dataPoint.Dimensions[CR_KIND])
+	require.Equal(t, "apps", dataPoint.Dimensions[CR_GROUP])
+	require.Equal(t, "v1", dataPoint.Dimensions[CR_VERSION])
+	require.Equal(t, "apps/v1", dataPoint.Dimensions[CR_APIVERSION])
+}
+
+func TestExtractProjectionGroupsWithResourceGVK(t *testing.T) {
+	pod := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "pod",
+			"namespace": "default",
+		},
+	}}
+	deployment := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "deployment",
+			"namespace": "default",
+		},
+	}}
+	list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{pod, deployment}}
+
+	groups := extractProjectionGroupsFromWithResourceGVK(list, nil, true)
+
+	require.Len(t, groups, 2)
+	require.Contains(t, groups, "cr_kind: Pod,cr_group: n/a,cr_version: v1,cr_api_version: v1")
+	require.Contains(t, groups, "cr_kind: Deployment,cr_group: apps,cr_version: v1,cr_api_version: apps/v1")
+}

--- a/internal/orchestrator/federatedhandler.go
+++ b/internal/orchestrator/federatedhandler.go
@@ -81,7 +81,7 @@ func (h *FederatedHandler) Monitor(ctx context.Context) (MonitorResult, error) {
 		return MonitorResult{}, fmt.Errorf("could not retrieve target resource(s) %w", err)
 	}
 
-	groups := extractProjectionGroupsFrom(list, h.metric.Spec.Projections)
+	groups := extractProjectionGroupsFromWithResourceGVK(list, h.metric.Spec.Projections, true)
 	valueByUID := resolveValueFrom(list, h.metric.Spec.ValueFrom)
 	dimensions := make(map[string]int)
 
@@ -89,12 +89,9 @@ func (h *FederatedHandler) Monitor(ctx context.Context) (MonitorResult, error) {
 		// Calculate count as the number of resource instances with this combination
 		count := len(fieldGroups)
 
-		dp := clientoptl.NewDataPoint().
-			AddDimension(CLUSTER, *h.clusterName).
-			AddDimension(RESOURCE, h.metric.Spec.Target.Kind).
-			AddDimension(GROUP, h.metric.Spec.Target.Group).
-			AddDimension(VERSION, h.metric.Spec.Target.Version).
-			SetValue(int64(count))
+		dp := clientoptl.NewDataPoint().SetValue(int64(count))
+		addClusterDimension(dp, h.clusterName)
+		addTargetGVKDimensions(dp, &h.metric.Spec.Target)
 
 		if len(fieldGroups) > 0 {
 			// Use aggregated valueFrom across all objects in the group if available

--- a/internal/orchestrator/federatedmanagedhandler.go
+++ b/internal/orchestrator/federatedmanagedhandler.go
@@ -37,6 +37,7 @@ func NewFederatedManagedHandler(metric v1alpha1.FederatedManagedMetric, qc Query
 		discoClient: disco,
 		gauge:       gaugeMetric,
 		clusterName: qc.ClusterName,
+		target:      qc.Target,
 	}
 
 	return handler, nil
@@ -52,6 +53,7 @@ type FederatedManagedHandler struct {
 
 	gauge       *clientoptl.Metric
 	clusterName *string
+	target      *v1alpha1.GroupVersionKindTarget
 }
 
 // Monitor is used to monitor the metric
@@ -70,6 +72,7 @@ func (h *FederatedManagedHandler) Monitor(ctx context.Context) (MonitorResult, e
 	}
 
 	var dimensions []v1alpha1.Dimension
+	target := h.target
 
 	// this is not right, we need to do a group by on the resources based on gvk
 
@@ -83,11 +86,11 @@ func (h *FederatedManagedHandler) Monitor(ctx context.Context) (MonitorResult, e
 
 	for _, cr := range resources {
 		dp := clientoptl.NewDataPoint().
-			AddDimension(CLUSTER, *h.clusterName).
-			AddDimension(KIND, cr.MangedResource.Kind).
-			AddDimension(APIVERSION, cr.MangedResource.APIVersion).
 			AddDimension("UUID", string(cr.MangedResource.Metadata.UID)). // this has to be unique, otherwise all the tuples are the same and the metric is not recorded properly
 			SetValue(int64(1))
+		addClusterDimension(dp, h.clusterName)
+		addTargetGVKDimensions(dp, target)
+		addResourceGVKDimensions(dp, gvkFromAPIVersionAndKind(cr.MangedResource.APIVersion, cr.MangedResource.Kind))
 
 		for fieldName, state := range cr.Status {
 			dp.AddDimension(fieldName, strconv.FormatBool(state))

--- a/internal/orchestrator/managedhandler.go
+++ b/internal/orchestrator/managedhandler.go
@@ -50,6 +50,7 @@ func NewManagedHandler(metric v1alpha1.ManagedMetric, qc QueryConfig, gaugeMetri
 }
 
 func (h *ManagedHandler) sendStatusBasedMetricValue(ctx context.Context) (string, error) {
+	target := h.metric.Spec.Target
 	l := log.FromContext(ctx)
 	resources, err := h.getResourcesStatus(ctx)
 	if err != nil {
@@ -61,18 +62,12 @@ func (h *ManagedHandler) sendStatusBasedMetricValue(ctx context.Context) (string
 		// Create a new data point for each resource
 		dataPoint := clientoptl.NewDataPoint()
 
+		addTargetGVKDimensions(dataPoint, target)
+		addResourceGVKDimensions(dataPoint, gvkFromAPIVersionAndKind(cr.MangedResource.APIVersion, cr.MangedResource.Kind))
+
 		// Preserve old logic so that if custom dimensions are not set, we use status.conditions
 		// as default dimensions
 		if h.metric.Spec.Dimensions == nil {
-			gv, err := schema.ParseGroupVersion(cr.MangedResource.APIVersion)
-			if err != nil {
-				return "", err
-			}
-
-			dataPoint.AddDimension(KIND, cr.MangedResource.Kind)
-			dataPoint.AddDimension(GROUP, gv.Group)
-			dataPoint.AddDimension(VERSION, gv.Version)
-
 			for typ, state := range cr.Status {
 				t := strings.ToLower(typ)
 				if t == "ready" || t == "synced" {
@@ -99,10 +94,7 @@ func (h *ManagedHandler) sendStatusBasedMetricValue(ctx context.Context) (string
 			}
 		}
 
-		// Add cluster dimension if available
-		if h.clusterName != nil {
-			dataPoint.AddDimension(CLUSTER, *h.clusterName)
-		}
+		addClusterDimension(dataPoint, h.clusterName)
 
 		// Set the value to 1 for each resource
 		dataPoint.SetValue(1)

--- a/internal/orchestrator/metrichandler.go
+++ b/internal/orchestrator/metrichandler.go
@@ -53,10 +53,15 @@ func (h *MetricHandler) Monitor(ctx context.Context) (MonitorResult, error) {
 		return result, nil // Return error state, but not the error itself to controller
 	}
 
-	if len(h.metric.Spec.Projections) == 0 {
-		return h.simpleMonitor(ctx, list, lookup)
+	return h.monitorByProjectionGroups(ctx, list, lookup)
+}
+
+func (h *MetricHandler) monitorByProjectionGroups(ctx context.Context, list *unstructured.UnstructuredList, lookup targetLookupResult) (MonitorResult, error) {
+	groups := extractProjectionGroupsFromWithResourceGVK(list, h.metric.Spec.Projections, true)
+	if len(groups) > 0 {
+		return h.projectionsMonitor(ctx, list, lookup, groups)
 	}
-	return h.projectionsMonitor(ctx, list, lookup)
+	return h.simpleMonitor(ctx, list, lookup)
 }
 
 func (h *MetricHandler) simpleMonitor(ctx context.Context, list *unstructured.UnstructuredList, lookup targetLookupResult) (MonitorResult, error) {
@@ -91,8 +96,7 @@ func (h *MetricHandler) simpleMonitor(ctx context.Context, list *unstructured.Un
 	}, nil
 }
 
-func (h *MetricHandler) projectionsMonitor(ctx context.Context, list *unstructured.UnstructuredList, lookup targetLookupResult) (MonitorResult, error) {
-	groups := extractProjectionGroupsFrom(list, h.metric.Spec.Projections)
+func (h *MetricHandler) projectionsMonitor(ctx context.Context, list *unstructured.UnstructuredList, lookup targetLookupResult, groups projectionGroups) (MonitorResult, error) {
 	result := MonitorResult{Observation: &v1alpha1.MetricObservation{Timestamp: metav1.Now()}}
 
 	// Pre-resolve valueFrom per object UID
@@ -166,22 +170,8 @@ func (h *MetricHandler) projectionsMonitor(ctx context.Context, list *unstructur
 }
 
 func (h *MetricHandler) setDataPointBaseDimensions(dataPoint *clientoptl.DataPoint) {
-	h.setDataPointBaseDimensionsFor(dataPoint, h.metric.Spec.Target.GVK())
-}
-
-func (h *MetricHandler) setDataPointBaseDimensionsFor(dataPoint *clientoptl.DataPoint, gvk schema.GroupVersionKind) {
-	if gvk.Kind != "" {
-		dataPoint.AddDimension(RESOURCE, gvk.Kind)
-	}
-	if gvk.Group != "" {
-		dataPoint.AddDimension(GROUP, gvk.Group)
-	}
-	if gvk.Version != "" {
-		dataPoint.AddDimension(VERSION, gvk.Version)
-	}
-	if h.clusterName != nil && *h.clusterName != "" {
-		dataPoint.AddDimension(CLUSTER, *h.clusterName)
-	}
+	addTargetGVKDimensions(dataPoint, &h.metric.Spec.Target)
+	addClusterDimension(dataPoint, h.clusterName)
 }
 
 type projectedField struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -12,23 +12,52 @@ import (
 )
 
 const (
-	// KIND Constant for k8s resource fields
+	// KIND Constant for k8s resource fields.
+	// Deprecated: use TARGET_KIND or CR_KIND for GVK dimensions.
 	KIND string = "kind"
 
-	// GROUP Constant for k8s resource fields
+	// GROUP Constant for k8s resource fields.
+	// Deprecated: use TARGET_GROUP or CR_GROUP for GVK dimensions.
 	GROUP string = "group"
 
-	// VERSION Constant for k8s resource fields
+	// VERSION Constant for k8s resource fields.
+	// Deprecated: use TARGET_VERSION or CR_VERSION for GVK dimensions.
 	VERSION string = "version"
 
 	// CLUSTER Constant for k8s resource fields
 	CLUSTER string = "cluster"
 
-	// RESOURCE Constant for k8s resource fields
+	// RESOURCE Constant for k8s resource fields.
+	// Deprecated: use TARGET_KIND or CR_KIND for GVK dimensions.
 	RESOURCE string = "resource"
 
-	// APIVERSION Constant for k8s resource fields
+	// APIVERSION Constant for k8s resource fields.
+	// Deprecated: use TARGET_APIVERSION or CR_APIVERSION for GVK dimensions.
 	APIVERSION string = "apiVersion"
+
+	// TARGET_KIND Constant for monitored spec.target kind dimension.
+	TARGET_KIND string = "target_kind"
+
+	// TARGET_GROUP Constant for monitored spec.target group dimension.
+	TARGET_GROUP string = "target_group"
+
+	// TARGET_VERSION Constant for monitored spec.target version dimension.
+	TARGET_VERSION string = "target_version"
+
+	// TARGET_APIVERSION Constant for monitored spec.target apiVersion dimension.
+	TARGET_APIVERSION string = "target_api_version"
+
+	// CR_KIND Constant for observed resource kind dimension.
+	CR_KIND string = "cr_kind"
+
+	// CR_GROUP Constant for observed resource group dimension.
+	CR_GROUP string = "cr_group"
+
+	// CR_VERSION Constant for observed resource version dimension.
+	CR_VERSION string = "cr_version"
+
+	// CR_APIVERSION Constant for observed resource apiVersion dimension.
+	CR_APIVERSION string = "cr_api_version"
 )
 
 // GenericHandler is used to monitor the metric
@@ -50,6 +79,7 @@ type QueryConfig struct {
 	Client      rcli.Client
 	RestConfig  rest.Config
 	ClusterName *string
+	Target      *v1alpha1.GroupVersionKindTarget
 }
 
 // NewOrchestrator creates a new Orchestrator

--- a/internal/orchestrator/projectionhelper.go
+++ b/internal/orchestrator/projectionhelper.go
@@ -281,11 +281,18 @@ func aggregateGroupValue(uids []string, valueByUID map[string]int64, vf *v1alpha
 
 // It returns a map where the key is a unique combination of projected values and the value is a list of groups of projected fields that share that combination.
 func extractProjectionGroupsFrom(list *unstructured.UnstructuredList, projections []v1alpha1.Projection) projectionGroups {
+	return extractProjectionGroupsFromWithResourceGVK(list, projections, false)
+}
+
+func extractProjectionGroupsFromWithResourceGVK(list *unstructured.UnstructuredList, projections []v1alpha1.Projection, includeResourceGVK bool) projectionGroups {
 	collection := make([][]projectedField, 0, len(list.Items))
 
 	for _, obj := range list.Items {
 		uid := string(obj.GetUID())
 		var fields []projectedField
+		if includeResourceGVK {
+			fields = append(fields, resourceGVKProjectedFields(obj)...)
+		}
 		for _, projection := range projections {
 			if projection.Name != "" && projection.FieldPath != "" {
 				name := projection.Name


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements #93 Option B on top of #253.

All exported metrics now distinguish the configured target GVK from the observed resource/CR GVK:

- `target_kind`, `target_group`, `target_version`, `target_api_version` from `spec.target`
- `cr_kind`, `cr_group`, `cr_version`, `cr_api_version` from the observed resource instance
- `cluster` remains unchanged

For `Metric` and `FederatedMetric`, observed resource GVK is included in the grouping dimensions, which matters with #253 partial target matching because one target can resolve to multiple GVKs.

For `ManagedMetric` and `FederatedManagedMetric`, target GVK labels and observed CR GVK labels are exported consistently alongside existing status/custom dimensions. Federated managed target labels are propagated from the referenced `FederatedClusterAccess` target through `QueryConfig`.

The Prometheus mirror gauge labels were updated to the explicit target/CR GVK names, and docs/tests were updated.

###  TODO

 * How does this feature align with the `dimensions`? 


**Which issue(s) this PR fixes**:
Fixes #93
Depends on #253

**Special notes for your reviewer**:

- This PR is intentionally based on `feat/cache-lookup` to keep the diff focused while #253 is pending. Once #253 lands, this branch can be retargeted to `main`.
- Empty GVK parts are exported as `n/a` so label dimensions stay explicit and consistent.

**Release note**:
```feature user
Metric exports now include explicit target GVK labels (`target_kind`, `target_group`, `target_version`, `target_api_version`) and observed resource GVK labels (`cr_kind`, `cr_group`, `cr_version`, `cr_api_version`) across metric types.
```