### PR TITLE
chore: Add concurrency cancellation to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/validate-pr-content.yaml
+++ b/.github/workflows/validate-pr-content.yaml
@@ -6,6 +6,10 @@ on:
       - opened
       - edited
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a concurrency block to GitHub Actions workflows so that in-progress runs are automatically cancelled when a new commit is pushed to the same PR.
see issue https://github.com/openmcp-project/service-provider-template/issues/79

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/service-provider-template/issues/79

**Special notes for your reviewer**:

**Release note**:

```other dependency

```