### PR TITLE
feat: set default OTEL_SERVICE_NAME in helm chart

### DIFF
--- a/charts/metrics-operator/values.yaml
+++ b/charts/metrics-operator/values.yaml
@@ -44,7 +44,9 @@ manager:
   args: []
   extraArgs: []
 
-  env: []
+  env:
+  - name: OTEL_SERVICE_NAME
+    value: metrics-operator
   # Extra environment variables to add to the manager container.
   extraEnv: []
 

--- a/charts/metrics-operator/values.yaml
+++ b/charts/metrics-operator/values.yaml
@@ -45,8 +45,11 @@ manager:
   extraArgs: []
 
   env:
-  - name: OTEL_SERVICE_NAME
-    value: metrics-operator
+  - name: "OTEL_SERVICE_NAME"
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+        
   # Extra environment variables to add to the manager container.
   extraEnv: []
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets `OTEL_SERVICE_NAME=metrics-operator` as a default environment variable in the manager container helm values. Without this, OTel defaults to `unknown_service:metrics-operator` (derived from the process binary name), making metrics harder to identify in observability backends like CLS.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`OTEL_SERVICE_NAME` is a standard OTel env var respected natively by the Go OTel SDK — no code changes required. Overridable per-deployment via `manager.env` or `manager.extraEnv` in values.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Set default OTEL_SERVICE_NAME=metrics-operator in helm chart to avoid unknown_service label in metrics.
```