### PR TITLE
fix: reduce federated managed metric memory usage

### DIFF
--- a/internal/orchestrator/federatedmanagedhandler.go
+++ b/internal/orchestrator/federatedmanagedhandler.go
@@ -3,12 +3,13 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -17,6 +18,8 @@ import (
 	"github.com/openmcp-project/metrics-operator/api/v1alpha1"
 	"github.com/openmcp-project/metrics-operator/internal/clientoptl"
 )
+
+const federatedManagedListPageSize int64 = 500
 
 // NewFederatedManagedHandler creates a new FederatedManagedHandler
 func NewFederatedManagedHandler(metric v1alpha1.FederatedManagedMetric, qc QueryConfig, gaugeMetric *clientoptl.Metric) (*FederatedManagedHandler, error) {
@@ -54,13 +57,19 @@ type FederatedManagedHandler struct {
 	clusterName *string
 }
 
+type federatedManagedBucket struct {
+	cluster    string
+	kind       string
+	apiVersion string
+	ready      string
+	synced     string
+}
+
 // Monitor is used to monitor the metric
 func (h *FederatedManagedHandler) Monitor(ctx context.Context) (MonitorResult, error) {
-
 	result := MonitorResult{}
 
-	resources, err := h.getResourcesStatus(ctx)
-
+	count, err := h.recordManagedResourceCounts(ctx)
 	if err != nil {
 		result.Error = err
 		result.Phase = v1alpha1.PhaseFailed
@@ -69,100 +78,31 @@ func (h *FederatedManagedHandler) Monitor(ctx context.Context) (MonitorResult, e
 		return result, nil //nolint:nilerr
 	}
 
-	var dimensions []v1alpha1.Dimension
-
-	// this is not right, we need to do a group by on the resources based on gvk
-
-	// groups := lo.GroupBy(resources, func(r ClusterResourceStatus) string {
-	//	return fmt.Sprintf("%s/%s", r.MangedResource.Kind, r.MangedResource.APIVersion)
-	// })
-	//
-	// for _, group := range groups {
-	//
-	// }
-
-	for _, cr := range resources {
-		dp := clientoptl.NewDataPoint().
-			AddDimension(CLUSTER, *h.clusterName).
-			AddDimension(KIND, cr.MangedResource.Kind).
-			AddDimension(APIVERSION, cr.MangedResource.APIVersion).
-			AddDimension("UUID", string(cr.MangedResource.Metadata.UID)). // this has to be unique, otherwise all the tuples are the same and the metric is not recorded properly
-			SetValue(int64(1))
-
-		for fieldName, state := range cr.Status {
-			dp.AddDimension(fieldName, strconv.FormatBool(state))
-			dimensions = append(dimensions, v1alpha1.Dimension{Name: fieldName, Value: strconv.FormatBool(state)})
-		}
-
-		err = h.gauge.RecordMetrics(ctx, dp)
-		if err != nil {
-			return MonitorResult{}, fmt.Errorf("could not record metric: %w", err)
-		}
-
-	}
-
 	result.Phase = v1alpha1.PhaseActive
 	result.Reason = v1alpha1.ReasonMonitoringActive
 	result.Message = fmt.Sprintf("metric is monitoring federated managed resources '%s'", h.metric.Name)
-
-	if dimensions != nil {
-		result.Observation = &v1alpha1.MetricObservation{Timestamp: metav1.Now(), Dimensions: []v1alpha1.Dimension{{Name: dimensions[0].Name, Value: strconv.Itoa(len(resources))}}}
-	} else {
-		result.Observation = &v1alpha1.MetricObservation{Timestamp: metav1.Now()}
+	result.Observation = &v1alpha1.MetricObservation{
+		Timestamp:   metav1.Now(),
+		LatestValue: strconv.Itoa(count),
+		Dimensions:  []v1alpha1.Dimension{{Name: "resources", Value: strconv.Itoa(count)}},
 	}
 
 	return result, nil
-
 }
 
-func (h *FederatedManagedHandler) getResourcesStatus(ctx context.Context) ([]ClusterResourceStatus, error) {
-	managedResources, err := h.getManagedResources(ctx)
-	if err != nil {
-		return []ClusterResourceStatus{}, err
-	}
-
-	crStatuses := make([]ClusterResourceStatus, 0)
-
-	for _, item := range managedResources {
-		rsStatus := ClusterResourceStatus{MangedResource: item, Status: make(map[string]bool)}
-		for _, condition := range item.Status.Conditions {
-			status, _ := strconv.ParseBool(condition.Status)
-			rsStatus.Status[condition.Type] = status
-		}
-		crStatuses = append(crStatuses, rsStatus)
-	}
-
-	return crStatuses, nil
-}
-
-// is used to check if a resource from the cluster has a specific field
-func (h *FederatedManagedHandler) hasCategory(category string, crd apiextensionsv1.CustomResourceDefinition) bool {
-	for _, v := range crd.Spec.Names.Categories {
-		if v == category {
-			return true
-		}
-	}
-
-	return false
-}
-
-//nolint:gocyclo
-func (h *FederatedManagedHandler) getManagedResources(ctx context.Context) ([]Managed, error) {
-
+func (h *FederatedManagedHandler) recordManagedResourceCounts(ctx context.Context) (int, error) {
 	crds := &apiextensionsv1.CustomResourceDefinitionList{} // get ALL custom resource definitions
 	if err := h.client.List(ctx, crds); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	var resourceCRDs []apiextensionsv1.CustomResourceDefinition
+	counts := map[federatedManagedBucket]int64{}
+	total := 0
+
 	for _, crd := range crds.Items {
-		if h.hasCategory("crossplane", crd) && h.hasCategory("managed", crd) { // filter previously acquired crds
-			resourceCRDs = append(resourceCRDs, crd)
+		if !slices.Contains(crd.Spec.Names.Categories, "crossplane") || !slices.Contains(crd.Spec.Names.Categories, "managed") { // filter previously acquired crds
+			continue
 		}
-	}
-
-	var resources []unstructured.Unstructured
-	for _, crd := range resourceCRDs {
 
 		// Use the stored versions of the CRD
 		storedVersions := make(map[string]bool)
@@ -181,27 +121,77 @@ func (h *FederatedManagedHandler) getManagedResources(ctx context.Context) ([]Ma
 				Version:  crdv.Name,
 			}
 
-			list, err := h.dCli.Resource(gvr).List(ctx, metav1.ListOptions{}) // gets resources from all the available crds
-			if err != nil {
-				return nil, fmt.Errorf("could not find any matching resources for metric '%s'. %w", h.metric.Name, err)
-			}
+			opts := metav1.ListOptions{Limit: federatedManagedListPageSize}
+			for {
+				list, err := h.dCli.Resource(gvr).List(ctx, opts) // gets resources from all the available crds
+				if err != nil {
+					return total, fmt.Errorf("could not find any matching resources for metric '%s'. %w", h.metric.Name, err)
+				}
 
-			if len(list.Items) > 0 {
-				resources = append(resources, list.Items...)
+				for i := range list.Items {
+					item := &list.Items[i]
+					counts[federatedManagedBucket{
+						cluster:    h.clusterDimension(),
+						kind:       item.GetKind(),
+						apiVersion: item.GetAPIVersion(),
+						ready:      conditionStatus(item, "Ready"),
+						synced:     conditionStatus(item, "Synced"),
+					}]++
+					total++
+				}
+
+				if list.GetContinue() == "" {
+					break
+				}
+				opts.Continue = list.GetContinue()
 			}
 		}
 	}
 
-	managedResources := make([]Managed, 0, len(resources))
-	for _, u := range resources {
-		managed := Managed{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &managed)
-		if err != nil {
-			return nil, err
-		}
+	for bucket, count := range counts {
+		dataPoint := clientoptl.NewDataPoint().
+			AddDimension(CLUSTER, bucket.cluster).
+			AddDimension(KIND, bucket.kind).
+			AddDimension(APIVERSION, bucket.apiVersion).
+			AddDimension("Ready", bucket.ready).
+			AddDimension("Synced", bucket.synced).
+			SetValue(count)
 
-		managedResources = append(managedResources, managed)
+		if err := h.gauge.RecordMetrics(ctx, dataPoint); err != nil {
+			return total, fmt.Errorf("could not record metric: %w", err)
+		}
 	}
 
-	return managedResources, nil
+	return total, nil
+}
+
+func (h *FederatedManagedHandler) clusterDimension() string {
+	if h.clusterName == nil {
+		return ""
+	}
+	return *h.clusterName
+}
+
+func conditionStatus(item *unstructured.Unstructured, conditionType string) string {
+	conditions, ok, _ := unstructured.NestedSlice(item.Object, "status", "conditions")
+	if !ok {
+		return "unknown"
+	}
+
+	for _, condition := range conditions {
+		conditionMap, ok := condition.(map[string]any)
+		if !ok {
+			continue
+		}
+		if conditionMap["type"] != conditionType {
+			continue
+		}
+		status, ok := conditionMap["status"].(string)
+		if !ok {
+			return "unknown"
+		}
+		return strings.ToLower(status)
+	}
+
+	return "unknown"
 }

--- a/internal/orchestrator/federatedmanagedhandler.go
+++ b/internal/orchestrator/federatedmanagedhandler.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	rcli "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,16 +27,10 @@ func NewFederatedManagedHandler(metric v1alpha1.FederatedManagedMetric, qc Query
 		return nil, errCli
 	}
 
-	disco, errDisco := discovery.NewDiscoveryClientForConfig(&qc.RestConfig)
-	if errDisco != nil {
-		return nil, errDisco
-	}
-
 	var handler = &FederatedManagedHandler{
 		client:      qc.Client,
 		metric:      metric,
 		dCli:        dynamicClient,
-		discoClient: disco,
 		gauge:       gaugeMetric,
 		clusterName: qc.ClusterName,
 	}
@@ -47,9 +40,8 @@ func NewFederatedManagedHandler(metric v1alpha1.FederatedManagedMetric, qc Query
 
 // FederatedManagedHandler is used to monitor the metric
 type FederatedManagedHandler struct {
-	client      rcli.Client
-	dCli        dynamic.Interface
-	discoClient discovery.DiscoveryInterface
+	client rcli.Client
+	dCli   dynamic.Interface
 
 	metric v1alpha1.FederatedManagedMetric
 
@@ -104,14 +96,8 @@ func (h *FederatedManagedHandler) recordManagedResourceCounts(ctx context.Contex
 			continue
 		}
 
-		// Use the stored versions of the CRD
-		storedVersions := make(map[string]bool)
-		for _, v := range crd.Status.StoredVersions {
-			storedVersions[v] = true
-		}
-
 		for _, crdv := range crd.Spec.Versions {
-			if !crdv.Served || !storedVersions[crdv.Name] {
+			if !crdv.Served || !crdv.Storage {
 				continue
 			}
 

--- a/internal/orchestrator/federatedmanagedhandler_test.go
+++ b/internal/orchestrator/federatedmanagedhandler_test.go
@@ -35,9 +35,6 @@ func TestNewFederatedManagedHandler(t *testing.T) {
 	if handler.dCli == nil {
 		t.Fatal("expected dynamic client")
 	}
-	if handler.discoClient == nil {
-		t.Fatal("expected discovery client")
-	}
 	if handler.gauge != gauge {
 		t.Fatal("gauge was not preserved")
 	}

--- a/internal/orchestrator/federatedmanagedhandler_test.go
+++ b/internal/orchestrator/federatedmanagedhandler_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -147,6 +148,60 @@ func TestFederatedManagedRecordManagedResourceCountsAggregates(t *testing.T) {
 	}
 }
 
+func TestFederatedManagedRecordManagedResourceCountsUsesStorageVersion(t *testing.T) {
+	storageGVK := schema.GroupVersionKind{
+		Group:   "kubernetes.m.crossplane.io",
+		Version: "v1",
+		Kind:    "Object",
+	}
+	oldGVK := storageGVK
+	oldGVK.Version = "v1beta1"
+
+	handler := FederatedManagedHandler{
+		client: setupFakeClient(t, []string{fmt.Sprintf(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objects.kubernetes.m.crossplane.io
+spec:
+  group: kubernetes.m.crossplane.io
+  names:
+    categories:
+    - crossplane
+    - managed
+    kind: Object
+    listKind: ObjectList
+    plural: objects
+    singular: object
+  scope: Cluster
+  versions:
+  - name: %s
+    served: true
+    storage: false
+  - name: %s
+    served: true
+    storage: true
+status:
+  storedVersions:
+  - %s
+  - %s
+`, oldGVK.Version, storageGVK.Version, oldGVK.Version, storageGVK.Version)}),
+		dCli: setupFakeDynamicClient(t, []string{
+			fakeResource(oldGVK),
+			fakeResource(storageGVK),
+		}),
+		metric: v1alpha1.FederatedManagedMetric{},
+		gauge:  newTestGauge(t),
+	}
+
+	count, err := handler.recordManagedResourceCounts(context.Background())
+	if err != nil {
+		t.Fatalf("recordManagedResourceCounts failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("unexpected resource count: wanted=1, got=%d", count)
+	}
+}
+
 func TestFederatedManagedClusterDimensionDefaultsToEmpty(t *testing.T) {
 	handler := FederatedManagedHandler{}
 	if got := handler.clusterDimension(); got != "" {
@@ -227,7 +282,7 @@ func newTestGauge(t *testing.T) *clientoptl.Metric {
 }
 
 func federatedManagedCRD(gvk schema.GroupVersionKind) string {
-	return managedAndServedCRD(gvk) + `status:
+	return managedAndServedCRD(gvk) + "    storage: true\n" + `status:
   storedVersions:
   - ` + gvk.Version + `
 `

--- a/internal/orchestrator/federatedmanagedhandler_test.go
+++ b/internal/orchestrator/federatedmanagedhandler_test.go
@@ -1,0 +1,234 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/openmcp-project/metrics-operator/api/v1alpha1"
+	"github.com/openmcp-project/metrics-operator/internal/clientoptl"
+)
+
+func TestNewFederatedManagedHandler(t *testing.T) {
+	cluster := "test-cluster"
+	metric := v1alpha1.FederatedManagedMetric{}
+	metric.Spec.Name = "fed-managed"
+	gauge := newTestGauge(t)
+
+	handler, err := NewFederatedManagedHandler(metric, QueryConfig{
+		Client:      setupFakeClient(t, nil),
+		RestConfig:  rest.Config{Host: "https://example.invalid"},
+		ClusterName: &cluster,
+	}, gauge)
+	if err != nil {
+		t.Fatalf("NewFederatedManagedHandler failed: %v", err)
+	}
+	if handler.client == nil {
+		t.Fatal("expected client")
+	}
+	if handler.dCli == nil {
+		t.Fatal("expected dynamic client")
+	}
+	if handler.discoClient == nil {
+		t.Fatal("expected discovery client")
+	}
+	if handler.gauge != gauge {
+		t.Fatal("gauge was not preserved")
+	}
+	if handler.clusterName == nil || *handler.clusterName != cluster {
+		t.Fatalf("unexpected cluster name: %v", handler.clusterName)
+	}
+	if handler.metric.Spec.Name != metric.Spec.Name {
+		t.Fatalf("unexpected metric name: wanted=%q, got=%q", metric.Spec.Name, handler.metric.Spec.Name)
+	}
+}
+
+func TestFederatedManagedMonitorRecordsAggregatedObservation(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "kubernetes.m.crossplane.io",
+		Version: "v1alpha1",
+		Kind:    "Object",
+	}
+	cluster := "test-cluster"
+
+	handler := FederatedManagedHandler{
+		client:      setupFakeClient(t, []string{federatedManagedCRD(gvk)}),
+		dCli:        setupFakeDynamicClient(t, []string{fakeResource(gvk), fakeResource(gvk)}),
+		metric:      v1alpha1.FederatedManagedMetric{},
+		gauge:       newTestGauge(t),
+		clusterName: &cluster,
+	}
+
+	result, err := handler.Monitor(context.Background())
+	if err != nil {
+		t.Fatalf("Monitor failed: %v", err)
+	}
+	if result.Phase != v1alpha1.PhaseActive {
+		t.Fatalf("unexpected phase: wanted=%s, got=%s", v1alpha1.PhaseActive, result.Phase)
+	}
+	if result.Observation.GetValue() != "2" {
+		t.Fatalf("unexpected observation value: wanted=2, got=%s", result.Observation.GetValue())
+	}
+}
+
+func TestFederatedManagedMonitorReportsListErrors(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "kubernetes.m.crossplane.io",
+		Version: "v1alpha1",
+		Kind:    "Object",
+	}
+	dynamicClient := setupFakeDynamicClient(t, []string{fakeResource(gvk)})
+	dynamicClient.PrependReactor("list", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("boom")
+	})
+
+	handler := FederatedManagedHandler{
+		client: setupFakeClient(t, []string{federatedManagedCRD(gvk)}),
+		dCli:   dynamicClient,
+		metric: v1alpha1.FederatedManagedMetric{},
+		gauge:  newTestGauge(t),
+	}
+
+	result, err := handler.Monitor(context.Background())
+	if err != nil {
+		t.Fatalf("Monitor returned unexpected error: %v", err)
+	}
+	if result.Phase != v1alpha1.PhaseFailed {
+		t.Fatalf("unexpected phase: wanted=%s, got=%s", v1alpha1.PhaseFailed, result.Phase)
+	}
+	if result.Error == nil {
+		t.Fatal("expected result error")
+	}
+}
+
+func TestFederatedManagedRecordManagedResourceCountsAggregates(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "kubernetes.m.crossplane.io",
+		Version: "v1alpha1",
+		Kind:    "Object",
+	}
+	cluster := "test-cluster"
+	gauge := newTestGauge(t)
+
+	records := make(map[string]int64)
+	gauge.SetPrometheusFunc(func(dims map[string]string, value int64) {
+		if _, ok := dims["UUID"]; ok {
+			t.Errorf("unexpected UUID dimension: %v", dims)
+		}
+		records[dims[CLUSTER]+"|"+dims[KIND]+"|"+dims[APIVERSION]+"|"+dims["Ready"]+"|"+dims["Synced"]] = value
+	})
+
+	handler := FederatedManagedHandler{
+		client:      setupFakeClient(t, []string{federatedManagedCRD(gvk)}),
+		dCli:        setupFakeDynamicClient(t, []string{fakeResource(gvk), fakeResource(gvk)}),
+		metric:      v1alpha1.FederatedManagedMetric{},
+		gauge:       gauge,
+		clusterName: &cluster,
+	}
+
+	count, err := handler.recordManagedResourceCounts(context.Background())
+	if err != nil {
+		t.Fatalf("recordManagedResourceCounts failed: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("unexpected resource count: wanted=2, got=%d", count)
+	}
+	key := "test-cluster|Object|kubernetes.m.crossplane.io/v1alpha1|true|true"
+	if records[key] != 2 {
+		t.Fatalf("unexpected aggregated records: wanted %q=2, got %#v", key, records)
+	}
+	if len(records) != 1 {
+		t.Fatalf("unexpected record count: wanted=1, got=%d (%#v)", len(records), records)
+	}
+}
+
+func TestFederatedManagedClusterDimensionDefaultsToEmpty(t *testing.T) {
+	handler := FederatedManagedHandler{}
+	if got := handler.clusterDimension(); got != "" {
+		t.Fatalf("unexpected cluster dimension: wanted empty, got=%q", got)
+	}
+}
+
+func TestFederatedManagedConditionStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		resource      string
+		conditionType string
+		want          string
+	}{
+		{
+			name:          "present condition",
+			resource:      fakeResource(schema.GroupVersionKind{Group: "kubernetes.m.crossplane.io", Version: "v1alpha1", Kind: "Object"}),
+			conditionType: "Ready",
+			want:          "true",
+		},
+		{
+			name: "missing conditions",
+			resource: `apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: missing
+`,
+			conditionType: "Ready",
+			want:          "unknown",
+		},
+		{
+			name:          "missing condition type",
+			resource:      fakeResource(schema.GroupVersionKind{Group: "kubernetes.m.crossplane.io", Version: "v1alpha1", Kind: "Object"}),
+			conditionType: "Missing",
+			want:          "unknown",
+		},
+		{
+			name: "non string status",
+			resource: `apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: bad-status
+status:
+  conditions:
+  - type: Ready
+    status: true
+`,
+			conditionType: "Ready",
+			want:          "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := toUnstructured(t, tt.resource)
+			if got := conditionStatus(&item, tt.conditionType); got != tt.want {
+				t.Fatalf("unexpected condition status: wanted=%q, got=%q", tt.want, got)
+			}
+		})
+	}
+}
+
+func newTestGauge(t *testing.T) *clientoptl.Metric {
+	t.Helper()
+
+	metricClient, err := clientoptl.NewMetricClient(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("failed to create metric client: %v", err)
+	}
+	metricClient.SetMeter("test")
+
+	gauge, err := metricClient.NewMetric("test_metric")
+	if err != nil {
+		t.Fatalf("failed to create gauge: %v", err)
+	}
+
+	return gauge
+}
+
+func federatedManagedCRD(gvk schema.GroupVersionKind) string {
+	return managedAndServedCRD(gvk) + `status:
+  storedVersions:
+  - ` + gvk.Version + `
+`
+}

--- a/internal/orchestrator/managedhandler_test.go
+++ b/internal/orchestrator/managedhandler_test.go
@@ -307,7 +307,7 @@ func yamlNameGVK(t *testing.T, yaml string) string {
 
 func fakeResource(gvk schema.GroupVersionKind) string {
 	return fmt.Sprintf(`apiVersion: %v
-kind: %v 
+kind: %v
 metadata:
   name: %v
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduces `FederatedManagedMetric` memory usage when collecting Crossplane managed-resource metrics across federated MCP clusters.

Previously the handler listed every matching managed resource without pagination, kept all returned objects in memory, converted them to full `Managed` structs, and emitted one datapoint per resource using `UUID` as a uniqueness dimension. On large landscapes this creates high peak memory usage and high metric-cardinality pressure.

This PR changes the handler to:

- list managed resources with paginated Kubernetes API calls (`limit`/`continue`)
- process each page directly instead of accumulating all objects
- read `Ready`/`Synced` status conditions from `unstructured.Unstructured`
- aggregate resources by `(cluster, kind, apiVersion, Ready, Synced)`
- emit one datapoint per aggregate bucket with `value=<count>`
- remove the per-resource `UUID` dimension

The old `UUID` dimension existed because the previous implementation emitted one datapoint per managed resource with `value=1`. Without a unique dimension, datapoints with the same metric name and same labels (`cluster`, `kind`, `apiVersion`, condition labels) collapse into the same time series in the metrics backend, so the count is not represented correctly.

This change intentionally changes the metric shape: the operator now aggregates resources first and emits one datapoint per `(cluster, kind, apiVersion, Ready, Synced)` bucket with `value=<count>`. Because the count is already aggregated by the operator, a per-resource UUID dimension is no longer needed. Keeping `UUID` would recreate the original high-cardinality problem: one time series per managed resource, across all MCP clusters, every minute.

Tradeoff: this removes per-resource UUID visibility from the metric stream, but preserves the operational signal needed for alerting/counting while avoiding high memory usage and backend cardinality pressure. Per-resource investigation should happen via Kubernetes queries/logs, not via metrics labels.

**Which issue(s) this PR fixes**:

This fixes an internally tracked ticket

**Special notes for your reviewer**:


**Release note**:
```bugfix operator
Reduce FederatedManagedMetric memory usage and metric cardinality by paginating managed-resource list calls and exporting aggregated resource counts instead of one UUID-labelled datapoint per resource.
```
